### PR TITLE
fix zsh shell aliases to not be global

### DIFF
--- a/home-manager/pascal/modules/zsh.nix
+++ b/home-manager/pascal/modules/zsh.nix
@@ -67,9 +67,8 @@ in
 
       };
 
-      # define shell aliases which are substituted anywhere on a line
-      # https://home-manager-options.extranix.com/?query=programs.zsh.shellGlobalAliases&release=master
-      shellGlobalAliases = {
+      # https://home-manager-options.extranix.com/?query=programs.zsh.shellAliases&release=master
+      shellAliases = {
         # general
         ls = "lsd";
         ll = "lsd -la";


### PR DESCRIPTION
global aliases are substituted anywhere on a line, e.g.: `echo vscode` would print `code` rather than printing `vscode`

the aliases here look like they should only be interpreted as aliases when they're used as commands, e.g. at the start of a terminal line